### PR TITLE
Update ffi and ref dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
   },
   "homepage": "https://github.com/oledid-js/windows-api-show-window#readme",
   "dependencies": {
-    "ffi": "^2.2.0",
-    "ref": "^1.3.4"
+    "ffi-napi": "^3.0.1",
+    "ref-napi": "^2.0.1"
   },
   "devDependencies": {
-    "@types/ffi": "0.0.19",
+    "@types/ffi-napi": "2.4.3",
     "@types/node": "^6.0.0",
-    "@types/ref": "0.0.28",
+    "@types/ref-napi": "1.4.1",
     "in-publish": "^2.0.0",
     "tslint": "^4.4.2",
     "typescript": "^2.1.6"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,10 @@
-import * as path from "path";
-import * as ffi from "ffi";
+import * as ffi from "ffi-napi";
 import * as os from "os";
-const ref = require("ref");
+import * as ref from "ref-napi";
+
+declare module "ref-napi" {
+	export function deref(buffer?: Buffer): any;
+}
 
 let HWND = 0;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,8 @@
     "strictNullChecks": true,
     "types": [
       "node",
-      "ffi",
-      "ref"
+      "ffi-napi",
+      "ref-napi"
     ]
   },
   "include": [


### PR DESCRIPTION
ffi and ref packages are abandoned and incompatible with latest Node versions (12 and 14 at least). Switched to up-to-date *-napi forks with no issues.